### PR TITLE
Fix linked.update_linked_album() for Immich v3.0.x (album_user schema change)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,10 @@ A robust SQL-based automation tool for **synchronizing and sharing assets** acro
 
 ### ✅ Tested Immich version: **v2.7.5**
 
+### 🩹 Immich v3.0.x note
+
+Immich v3.0 removed `album.ownerId` (owner is now a row in `album_user` with `role='owner'`), which broke `linked.update_linked_album()` with `column a.ownerId does not exist`. This has been patched and validated (create/delete linked album, ownership assignment) against **v3.0.3**. Only the album-linking trigger path was re-tested against v3 — if you hit issues elsewhere in the mod on v3.x, please open an issue.
+
 ---
 
 ## 🚀 Overview

--- a/immich_linked_asset.sql
+++ b/immich_linked_asset.sql
@@ -878,37 +878,39 @@ BEGIN
 	IF NOT EXISTS (SELECT 1 FROM linked.shared_album WHERE id = new.id) THEN
 		IF new.description = 'create linked album' THEN
 			--- new linked album
-			with base as (select a."albumName" as album_name, uuid_generate_v4() as shared_album_cluster, 
-					la.album_cluster, a."ownerId" as owner_id, true as base_owner, a.id from public.album as a
-				left join linked.album as la on a."ownerId" = la.owner_id
-				where a.id = new.id),
-			final_album as (
-				select album_name, shared_album_cluster, owner_id, base_owner, id from base
-				union all
-				select b.album_name, b.shared_album_cluster, ls.owner_id, false, uuid_generate_v4() from base as b
-				left join linked.album as ls using (album_cluster)
-				where ls.owner_id != b.owner_id),
+			-- Immich v3.0+ removed album.ownerId; ownership now lives in album_user (role='owner')
+			CREATE TEMP TABLE tmp_final_album ON COMMIT DROP AS
+			with base as (select a."albumName" as album_name, uuid_generate_v4() as shared_album_cluster,
+					la.album_cluster, au."userId" as owner_id, true as base_owner, a.id from public.album as a
+				join public.album_user as au on au."albumId" = a.id and au.role = 'owner'
+				left join linked.album as la on au."userId" = la.owner_id
+				where a.id = new.id)
+			select album_name, shared_album_cluster, owner_id, base_owner, id from base
+			union all
+			select b.album_name, b.shared_album_cluster, ls.owner_id, false, uuid_generate_v4() from base as b
+			left join linked.album as ls using (album_cluster)
+			where ls.owner_id != b.owner_id;
+
 			--- into album
-			joined AS (SELECT 
-				n.id as new_id,
-				n.owner_id,
-				to_jsonb(t) AS data
-				FROM final_album as m
-				left JOIN public.album as t ON t.id = m.id
-				inner JOIN final_album as n ON m.shared_album_cluster = n.shared_album_cluster
-				where m.id = new.id and n.id != new.id),
-			patched AS (SELECT data || jsonb_build_object('id', to_jsonb(new_id), 
-										'description', to_jsonb(''::text),
-										'ownerId', to_jsonb(owner_id)) AS new_data FROM joined),
-			insert_album as (
-				INSERT INTO public.album
-				SELECT (jsonb_populate_record(NULL::public.album, new_data)).*
-				FROM patched
-				ON CONFLICT (id) DO NOTHING
-				RETURNING 1)
+			INSERT INTO public.album
+			SELECT (jsonb_populate_record(NULL::public.album, to_jsonb(t) || jsonb_build_object(
+						'id', to_jsonb(f.id),
+						'description', to_jsonb(''::text)))).*
+			FROM tmp_final_album AS f
+			JOIN public.album AS t ON t.id = new.id
+			WHERE f.id != new.id
+			ON CONFLICT (id) DO NOTHING;
+
+			--- assign ownership on each cloned album
+			INSERT INTO public.album_user ("albumId", "userId", role)
+			SELECT id, owner_id, 'owner'::album_user_role_enum
+			FROM tmp_final_album
+			WHERE id != new.id
+			ON CONFLICT ("albumId") WHERE role = 'owner'::album_user_role_enum DO NOTHING;
+
 			--- into linked.shared_album
 			insert into linked.shared_album (album_name,shared_album_cluster,owner_id,base_owner,id)
-			select album_name, shared_album_cluster, owner_id, base_owner, id from final_album
+			select album_name, shared_album_cluster, owner_id, base_owner, id from tmp_final_album
 			on conflict (id) do nothing;
 			INSERT INTO public.album_asset ("albumId","assetId")
 			with base as (select a.id, a.asset_cluster, sa.shared_album_cluster from public.album_asset as ta
@@ -918,7 +920,7 @@ BEGIN
 			select lt.id, a.id from base as b
 			inner join linked.asset as a using (asset_cluster)
 			inner join linked.shared_album as lt using (shared_album_cluster,owner_id)
-			where lt.id != new.id 
+			where lt.id != new.id
 			on conflict ("albumId","assetId") do nothing;
 			update public.album set description = '' where id = new.id;
 		END IF;

--- a/immich_update_linked_trigger.sql
+++ b/immich_update_linked_trigger.sql
@@ -321,37 +321,39 @@ BEGIN
 	IF NOT EXISTS (SELECT 1 FROM linked.shared_album WHERE id = new.id) THEN
 		IF new.description = 'create linked album' THEN
 			--- new linked album
-			with base as (select a."albumName" as album_name, uuid_generate_v4() as shared_album_cluster, 
-					la.album_cluster, a."ownerId" as owner_id, true as base_owner, a.id from public.album as a
-				left join linked.album as la on a."ownerId" = la.owner_id
-				where a.id = new.id),
-			final_album as (
-				select album_name, shared_album_cluster, owner_id, base_owner, id from base
-				union all
-				select b.album_name, b.shared_album_cluster, ls.owner_id, false, uuid_generate_v4() from base as b
-				left join linked.album as ls using (album_cluster)
-				where ls.owner_id != b.owner_id),
+			-- Immich v3.0+ removed album.ownerId; ownership now lives in album_user (role='owner')
+			CREATE TEMP TABLE tmp_final_album ON COMMIT DROP AS
+			with base as (select a."albumName" as album_name, uuid_generate_v4() as shared_album_cluster,
+					la.album_cluster, au."userId" as owner_id, true as base_owner, a.id from public.album as a
+				join public.album_user as au on au."albumId" = a.id and au.role = 'owner'
+				left join linked.album as la on au."userId" = la.owner_id
+				where a.id = new.id)
+			select album_name, shared_album_cluster, owner_id, base_owner, id from base
+			union all
+			select b.album_name, b.shared_album_cluster, ls.owner_id, false, uuid_generate_v4() from base as b
+			left join linked.album as ls using (album_cluster)
+			where ls.owner_id != b.owner_id;
+
 			--- into album
-			joined AS (SELECT 
-				n.id as new_id,
-				n.owner_id,
-				to_jsonb(t) AS data
-				FROM final_album as m
-				left JOIN public.album as t ON t.id = m.id
-				inner JOIN final_album as n ON m.shared_album_cluster = n.shared_album_cluster
-				where m.id = new.id and n.id != new.id),
-			patched AS (SELECT data || jsonb_build_object('id', to_jsonb(new_id), 
-										'description', to_jsonb(''::text),
-										'ownerId', to_jsonb(owner_id)) AS new_data FROM joined),
-			insert_album as (
-				INSERT INTO public.album
-				SELECT (jsonb_populate_record(NULL::public.album, new_data)).*
-				FROM patched
-				ON CONFLICT (id) DO NOTHING
-				RETURNING 1)
+			INSERT INTO public.album
+			SELECT (jsonb_populate_record(NULL::public.album, to_jsonb(t) || jsonb_build_object(
+						'id', to_jsonb(f.id),
+						'description', to_jsonb(''::text)))).*
+			FROM tmp_final_album AS f
+			JOIN public.album AS t ON t.id = new.id
+			WHERE f.id != new.id
+			ON CONFLICT (id) DO NOTHING;
+
+			--- assign ownership on each cloned album
+			INSERT INTO public.album_user ("albumId", "userId", role)
+			SELECT id, owner_id, 'owner'::album_user_role_enum
+			FROM tmp_final_album
+			WHERE id != new.id
+			ON CONFLICT ("albumId") WHERE role = 'owner'::album_user_role_enum DO NOTHING;
+
 			--- into linked.shared_album
 			insert into linked.shared_album (album_name,shared_album_cluster,owner_id,base_owner,id)
-			select album_name, shared_album_cluster, owner_id, base_owner, id from final_album
+			select album_name, shared_album_cluster, owner_id, base_owner, id from tmp_final_album
 			on conflict (id) do nothing;
 			INSERT INTO public.album_asset ("albumId","assetId")
 			with base as (select a.id, a.asset_cluster, sa.shared_album_cluster from public.album_asset as ta
@@ -361,7 +363,7 @@ BEGIN
 			select lt.id, a.id from base as b
 			inner join linked.asset as a using (asset_cluster)
 			inner join linked.shared_album as lt using (shared_album_cluster,owner_id)
-			where lt.id != new.id 
+			where lt.id != new.id
 			on conflict ("albumId","assetId") do nothing;
 			update public.album set description = '' where id = new.id;
 		END IF;


### PR DESCRIPTION
## Problem

Immich v3.0.0 shipped `chore!: migrate album owner to album_user` (immich-app/immich#27467),
which **removed** `public.album.ownerId` — not renamed, removed. Album ownership now lives in
`public.album_user` as a row with `role = 'owner'`.

`linked.update_linked_album()` still read `a."ownerId"`, so every album update that hit this
trigger failed with:

    PostgresError: column a.ownerId does not exist   (SQLSTATE 42703)
    where: PL/pgSQL function linked.update_linked_album() line 8 at SQL statement

This made `create linked album` / `delete linked album` non-functional, and any other album
edit that hit the trigger rolled back.

## Fix

- Owner is now resolved via `join public.album_user au on au."albumId" = a.id and au.role = 'owner'`
  instead of reading `a."ownerId"`.
- Cloned albums now get an explicit `INSERT INTO public.album_user (...)` row with `role='owner'`
  — previously the code built a jsonb `'ownerId'` key to smuggle ownership onto the clone, which
  `jsonb_populate_record` silently drops since the column no longer exists. Clones were being
  created with **no owner at all**.
- Restructured the single CTE chain into ordered statements (clone set → album insert → album_user
  insert → shared_album insert) so the album_user insert is guaranteed to run after the album
  insert it has an FK dependency on, instead of relying on unspecified CTE execution order.
- Applied identically to both `immich_update_linked_trigger.sql` (trigger-only reinstall) and
  `immich_linked_asset.sql` (full install), since they carried duplicate copies of the function.
- Confirmed `linked.album` / `linked.shared_album` (which store `owner_id` as a plain user UUID)
  are unaffected by the v3 migration — no changes needed there.

Only `update_linked_album()` referenced the removed column; the other 23 functions in the `linked`
schema were checked and either don't touch album ownership or reference `asset.ownerId` /
`stack.ownerId`, which v3 did not remove.

## Testing

Validated live against **Immich v3.0.3**:
- `create linked album` clones the album to all linked users, each with exactly one
  `album_user` row (`role='owner'`) pointing at the correct user — verified in the DB and in
  another user's app.
- `delete linked album` removes the clones and `linked.shared_album` entries — verified both
  are fully gone from the DB afterward.
- Zero `linked.*` / `42703` errors in server logs across both tests.

Not independently tested: earlier Immich versions (v2.x) — this only changes the owner
resolution path that v3 broke, so v2.x behavior should be unaffected, but wasn't re-verified.